### PR TITLE
support for karate debug-server via debug-adapter-protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 out
 node_modules
 karate-runner-*.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,7 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}",
-        "--disable-extensions"
+        "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": ["${workspaceFolder}/out/**/*.js"],
       "preLaunchTask": "npm: watch"

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
         "configurationAttributes": {
           "launch": {
             "properties": {
-              "program": {
+              "feature": {
                 "type": "string",
                 "description": "Absolute path to a feature file",
                 "default": "${file}"

--- a/package.json
+++ b/package.json
@@ -196,18 +196,49 @@
     "debuggers": [
       {
         "type": "karate",
-        "label": "Karate Debug",
+        "label": "Karate (debug)",
         "configurationAttributes": {
           "launch": {
+            "required": [
+              "feature",
+              "karateCli"
+            ],
             "properties": {
               "feature": {
                 "type": "string",
-                "description": "Absolute path to a feature file",
-                "default": "${file}"
+                "description": "Path to a Karate feature file",
+                "default": "^\"\\${file}\""
+              },
+              "karateCli": {
+                "type": "string",
+                "description": "Command to start debug server",
+                "default": "java -jar karate.jar -d"
               }
             }
           }
-        }
+        },
+        "initialConfigurations": [
+          {
+            "type": "karate",
+            "name": "Karate (debug)",
+            "request": "launch",
+            "feature": "${file}",
+            "karateCli": "java -jar karate.jar -d"
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "Karate (debug): Maven",
+            "description": "Karate (debug) for a Maven project",
+            "body": {
+              "type": "karate",
+              "name": "Karate (debug)",
+              "request": "launch",
+              "feature": "^\"\\${file}\"",
+              "karateCli": "mvn exec:java -Dexec.mainClass='com.intuit.karate.cli.Main' -Dexec.args='-d' -Dexec.classpathScope=test"
+            }
+          }
+        ]
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -187,7 +187,29 @@
           "scope": "resource"
         }
       }
-    }
+    },
+    "breakpoints": [
+      {
+        "language": "feature"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "karate",
+        "label": "Karate Debug",
+        "configurationAttributes": {
+          "launch": {
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Absolute path to a feature file",
+                "default": "${file}"
+              }
+            }
+          }
+        }
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,15 +111,14 @@ export function activate(context: vscode.ExtensionContext)
       let watcher = vscode.workspace.createFileSystemWatcher(relativePattern);
       let watcherPromise = new Promise<number>(resolve => {
         watcher.onDidChange(e => {
-          let portFilePath = e.fsPath;
-          let portString = fs.readFileSync(portFilePath, { encoding: 'utf8' });
+          let portString = fs.readFileSync(e.fsPath, { encoding: 'utf8' });
           console.log("debug server ready on port:", portString);
           watcher.dispose();          
           resolve(parseInt(portString));
         });
       });
       let seo: vscode.ShellExecutionOptions = { cwd: projectRootPath };
-      let exec = new vscode.ShellExecution('java -jar karate.jar -d 4711', seo);
+      let exec = new vscode.ShellExecution(session.configuration.karateCli, seo);
       let task = new vscode.Task
       (
         { type: 'karate' },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,6 +102,31 @@ export function activate(context: vscode.ExtensionContext)
   context.subscriptions.push(refreshTestsTreeCommand);
   context.subscriptions.push(registerCodeLensProvider);
   context.subscriptions.push(openFileCommand);
+
+  context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('karate', {
+    createDebugAdapterDescriptor: (session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined) => {
+      let seo: vscode.ShellExecutionOptions = { cwd: vscode.workspace.rootPath };
+      let exec = new vscode.ShellExecution('java -jar karate.jar -d 4711', seo);
+      let task = new vscode.Task
+      (
+        { type: 'karate' },
+        vscode.TaskScope.Workspace,
+        'Karate Runner',
+        'karate',
+        exec,
+        []
+      );    
+      function sleep(time) {
+        return new Promise(resolve => {
+          setTimeout(resolve, time)
+        })
+      }            
+      return vscode.tasks.executeTask(task)
+       .then(() => sleep(5000))
+       .then(() => new vscode.DebugAdapterServer(4711));   
+    }
+  }));
+
 }
 
 export function deactivate()


### PR DESCRIPTION
the karate java project has added support for debugging by implementing a debug-adapter-protocol server: https://microsoft.github.io/debug-adapter-protocol/overview

this PR adds support for the VS Code plugin. it is very lightweight as all the heavy lifting is in the server. because of the protocol design, all enhancements can be done on the server-side, without any changes on the vscode side. most features are in place including the tricky and important nested `call` support ! with "step in" and "step out" working and multiple breakpoints. one of the TO-DO-s at this point is being able to "step back" but would like others to test this in the mean-time !

instructions:
- build karate from the `develop` branch locally: https://github.com/intuit/karate/wiki/Developer-Guide
- update your maven pom to refer to karate version `1.0.0` / or build the stand-alone jar and (rename it to `karate.jar`)
- run the extension in debug mode (launch profile `Extension`)
- in the second vs code instance, browse to a project
  - standalone: just use the debug config that will be created automatically on first-run / prompting (see below)
  - maven: use the `Add Configuration` button and choose the `Karate (debug): Maven` snippet
- now with a feature file in the editor, you can add breakpoints and hit the debug "play" button

launch profiles:

standalone:
```json
        {
            "type": "karate",
            "name": "Karate (debug)",
            "request": "launch",
            "feature": "${file}",
            "karateCli": "java -jar karate.jar -d"
        }
```

maven:
```json
        {
            "type": "karate",
            "name": "Karate (debug)",
            "request": "launch",
            "feature": "${file}",
            "karateCli": "mvn exec:java -Dexec.mainClass='com.intuit.karate.cli.Main' -Dexec.args='-d' -Dexec.classpathScope=test"
        }
```

advanced users can add a `"debugServer": 4711` line prop-value to the above launch-profile to talk to the karate debug-server directly, after it has been manually started (good for debugging or studying the protocol). there is a `DapServerRunner` in the `junit4` sub-project for this.
