### PR TITLE
adds HoverProvider to run/debug individual Examples in an Scenario Outline

### DIFF
--- a/src/HoverRunDebugProvider.ts
+++ b/src/HoverRunDebugProvider.ts
@@ -1,0 +1,36 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+/**
+ * HoverProvider that creates a tooltip with Karate run/debug buttons for this line.
+ */
+export default class HoverRunDebugProvider implements vscode.HoverProvider {
+    private extensionContext: vscode.ExtensionContext;
+
+    constructor(context: vscode.ExtensionContext) {
+        this.extensionContext = context;
+    }
+
+    public provideHover(document: vscode.TextDocument, position: vscode.Position, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+        const textLine = document.lineAt(position.line).text;
+
+        if (textLine.trim().startsWith('|')) {
+            const previousTextLine = document.lineAt(position.line - 1).text;
+            if (previousTextLine.trim().startsWith('|')) {
+                // is not the Examples Header or single row
+                const feature = `${document.uri.fsPath}:${position.line + 1}`;
+                let contents: vscode.MarkdownString = new vscode.MarkdownString();
+                contents.isTrusted = true;
+                const runArgs = encodeURIComponent(JSON.stringify([[feature, feature, document.uri, vscode.FileType.File]]));
+                const debugArgs = encodeURIComponent(JSON.stringify([[position.line + 1]]));
+                contents.appendMarkdown(`[Karate: Run](command:karateRunner.tests.run?${runArgs} "Karate: Run")`);
+                contents.appendMarkdown(' | ');
+                contents.appendMarkdown(`[Karate: Debug](command:karateRunner.tests.debug?${debugArgs} "Karate: Debug")`);
+
+                return new vscode.Hover(contents);
+            }
+        }
+        return null;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import ProviderExecutions from "./providerExecutions";
 import ProviderStatusBar from "./providerStatusBar";
 import ProviderCodeLens from "./providerCodeLens";
 import ProviderDefinition from "./providerDefinition";
+import HoverRunDebugProvider from './HoverRunDebugProvider';
 //import ProviderFoldingRange from "./providerFoldingRange";
 import { smartPaste, getDebugFile, getDebugBuildFile, debugKarateTest, runKarateTest, runAllKarateTests, displayReportsTree, displayTestsTree, openBuildReport, openFileInEditor } from "./commands";
 import * as vscode from 'vscode';
@@ -58,6 +59,7 @@ export function activate(context: vscode.ExtensionContext)
   buildReportsTreeView = vscode.window.createTreeView('karate-reports', { showCollapseAll: true, treeDataProvider: buildReportsProvider });
   karateTestsTreeView = vscode.window.createTreeView('karate-tests', { showCollapseAll: true, treeDataProvider: karateTestsProvider });
 
+  const registerHoverRunDebugProvider = vscode.languages.registerHoverProvider(codeLensTarget, new HoverRunDebugProvider(context));
   setupWatcher(
     buildReportsWatcher,
     String(vscode.workspace.getConfiguration('karateRunner.buildReports').get('toTarget')),
@@ -145,6 +147,7 @@ export function activate(context: vscode.ExtensionContext)
   context.subscriptions.push(registerDefinitionProvider);
   context.subscriptions.push(resultsProvider);
   //context.subscriptions.push(registerFoldingRangeProvider);
+  context.subscriptions.push(registerHoverRunDebugProvider);
 }
 
 export function deactivate()


### PR DESCRIPTION
Hi @kirksl 
we are using your extension and we may be sending you some PRs

This is a HoverProvider that creates a tooltip with Karate run/debug buttons for this line.
![image](https://user-images.githubusercontent.com/1246876/101152697-bac28e80-3623-11eb-9e38-4e5a8c0e8c2f.png)
