### PR TITLE
adding support to peek & auto-complete based on files available in the VS Code workspace

### DIFF
--- a/src/feature.ts
+++ b/src/feature.ts
@@ -243,7 +243,11 @@ class Feature
             {
                 let deref = this.dereferenceToken(tokens[ndx]);
 
-                if (deref === null) { return null; }
+                if (deref === null && ndx < tokens.length) {
+                    continue;
+                } else if (deref === null) {
+                    return null;
+                }
 
                 let lTokens = this.getLineTokens(deref);
                 let position: vscode.Position = new vscode.Position(0, deref.text.length);

--- a/src/providerDefinition.ts
+++ b/src/providerDefinition.ts
@@ -108,6 +108,15 @@ class ProviderDefinition implements vscode.DefinitionProvider
             {
                 return uriPath;
             }
+            
+            let workspaceFolders = vscode.workspace.workspaceFolders;
+            for (var i = 0; i < workspaceFolders.length; i ++) {
+                let workspaceUriPath = path.join(workspaceFolders[i].uri.fsPath, normalizedPath);
+                if (fs.existsSync(workspaceUriPath) && fs.lstatSync(workspaceUriPath).isFile())
+                {
+                    return workspaceUriPath;
+                }
+            }
         }
         
         return null;


### PR DESCRIPTION
I never realized peek was available since I don't have my Karate tests inside a java project and some of the code is pegged to the src folder etc.

This way it searches for files inside VSCode workspaces.

For the auto-complete when found inside a workspace and not in src/ it doesn't append classpath.