### PR TITLE
Fix for test results not showing in "Tests" window

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -348,7 +348,7 @@ function getChildAbsolutePath(basePath: string, childPath: string): string
 			}
 			else
 			{
-				if (newBasePath.toLowerCase().endsWith(childPath))
+				if (newBasePath.toLowerCase().endsWith(childPath.toLowerCase()))
 				{
 					result = newBasePath;
 				}


### PR DESCRIPTION
The tests window was not loading the results and the results tooltip in the editor window was not loading.  Tracked it down to uppercase characters in the test results path.