### PR TITLE
Get and use the expected JAVA_HOME environment setting.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "svg.preview.background": "transparent"
+    "svg.preview.background": "transparent",
+    "karateRunner.tests.toTargetByGlob": "**/test/**/*.feature"
 }

--- a/package.json
+++ b/package.json
@@ -616,6 +616,18 @@
 					"default": 0,
 					"description": "Number of spaces to indent data table rows from parent (eg Examples: | * table | * set | * replace).",
 					"scope": "resource"
+				},
+				"karateRunner.java.home": {
+					"type": "string",
+					"default": "",
+					"description": "Override java.home specifically for karate runner. Only applies when using Maven or Gradle.",
+					"scope": "resource"
+				},
+				"karateRunner.buildSystem.useDotSlashOnWindows": {
+					"type": "boolean",
+					"default": false,
+					"description": "Use `./gradlew` on windows. Only applies when using Gradle.",
+					"scope": "resource"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -622,12 +622,6 @@
 					"default": "",
 					"description": "Override java.home specifically for karate runner. Only applies when using Maven or Gradle.",
 					"scope": "resource"
-				},
-				"karateRunner.buildSystem.useDotSlashOnWindows": {
-					"type": "boolean",
-					"default": false,
-					"description": "Use `./gradlew` on windows. Only applies when using Gradle.",
-					"scope": "resource"
 				}
 			}
 		},

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -288,6 +288,16 @@ async function runKarateTest(args = null)
 		
   let karateEnv = String(vscode.workspace.getConfiguration('karateRunner.core').get('environment')).trim();
 
+	let javaHome = vscode.workspace.getConfiguration('karateRunner.java')?.get('home') ||
+		vscode.workspace.getConfiguration('java.import.gradle')?.get('java.home') ||
+		vscode.workspace.getConfiguration('java')?.get('home') ||
+		(vscode.workspace.getConfiguration('java.configuration.runtimes') || []).find(runtime => Boolean(runtime.get('default')))?.get('path');
+
+	let env = {};
+	if (javaHome) {
+		env['JAVA_HOME'] = javaHome;
+	}
+
 	if (runFilePath !== "" && !runFilePath.toLowerCase().endsWith(standaloneBuildFile))
 	{
 		if (!runFilePath.toLowerCase().endsWith(javaScriptBuildFile))
@@ -297,7 +307,7 @@ async function runKarateTest(args = null)
 				if (os.platform() == 'win32')
 				{
 					mavenCmd = "mvnw";
-					gradleCmd = "gradlew";
+					gradleCmd = vscode.workspace.getConfiguration('karateRunner.buildSystem').get('useDotSlashOnWindows') ? "./gradlew" : "gradlew";
 				}
 				else
 				{
@@ -454,7 +464,7 @@ async function runKarateTest(args = null)
 		}
 	});
 		
-	let seo: vscode.ShellExecutionOptions = { cwd: projectRootPath };
+	let seo: vscode.ShellExecutionOptions = { cwd: projectRootPath, env: env };
 	if (os.platform() == 'win32')
 	{
 		seo.executable = "cmd.exe";

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -286,12 +286,14 @@ async function runKarateTest(args = null)
 	let projectRootPath = projectDetail.projectRoot;
 	let runFilePath = projectDetail.runFile;
 		
-  let karateEnv = String(vscode.workspace.getConfiguration('karateRunner.core').get('environment')).trim();
+	let karateEnv = String(vscode.workspace.getConfiguration('karateRunner.core').get('environment')).trim();
+
+	const javaRuntimes: any[] = vscode.workspace.getConfiguration('java.configuration').get('runtimes', []);
 
 	let javaHome = vscode.workspace.getConfiguration('karateRunner.java')?.get('home') ||
 		vscode.workspace.getConfiguration('java.import.gradle')?.get('java.home') ||
 		vscode.workspace.getConfiguration('java')?.get('home') ||
-		(vscode.workspace.getConfiguration('java.configuration.runtimes') || []).find(runtime => Boolean(runtime.get('default')))?.get('path');
+		javaRuntimes.find(runtime => runtime.default)?.path;
 
 	let env = {};
 	if (javaHome) {
@@ -307,7 +309,7 @@ async function runKarateTest(args = null)
 				if (os.platform() == 'win32')
 				{
 					mavenCmd = "mvnw";
-					gradleCmd = vscode.workspace.getConfiguration('karateRunner.buildSystem').get('useDotSlashOnWindows') ? "./gradlew" : "gradlew";
+					gradleCmd = `${vscode.workspace.workspaceFolders[0].uri.fsPath}\\gradlew.bat`; // Updated to use absolute path
 				}
 				else
 				{


### PR DESCRIPTION
Use in order of precedence

1. `karateRunner.java.home`
2. `java.home`
3. `java.import.gradle.java.home`
4. `java.configuration.runtimes` where default is true.

Apply the JAVA_HOME so that gradlew runs expected java version.

Fix? the running of gradlew.bat on Windows 10.
Was seeing `'gradlew' is not recognized as an internal or external command,
operable program or batch file.` despite gradlew.bat existing in the directory.